### PR TITLE
redis server response of (nil)  causes convert error

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -7,7 +7,7 @@ flatten(token::Dict) = map(string, vcat(map(collect, token)...))
 flatten_command(command...) = vcat(map(flatten, command)...)
 
 convert_response(::Any, response) = response
-convert_response(::Type{Float64}, response) = float(response)::Float64
+convert_response(::Type{Float64}, response) = response != nothing ? float(response)::Float64 : nothing
 convert_response(::Type{Bool}, response::String) = response == "OK" || response == "QUEUED" ? true : false
 convert_response(::Type{Bool}, response::Integer) = convert(Bool, response)
 convert_response(::Type{Set}, response) = Set(response)


### PR DESCRIPTION
as per the redis documentation: "The current score of an element can be retrieved using the ZSCORE command, that can also be used to verify if an element already exists or not."
Since we use this feature, thought I would propose at least this modification.  Not sure how it affects the rest of the library though, nor whether a similar modification needs to be made for the other convert_response methods. (EDIT: unfortunately, this mod interferes when the cmd is part of a multi transaction)

julia> score = zscore(conn,"a", objs[i]["name"])
ERROR: `convert` has no method matching convert(::Type{FloatingPoint}, ::Nothing)
 in float at float.jl:56
 in zscore at /home/ubuntu/.julia/v0.3/Redis/src/client.jl:69

John