### PR TITLE
fix parseint and import Base.get

### DIFF
--- a/src/Redis.jl
+++ b/src/Redis.jl
@@ -1,5 +1,7 @@
 module Redis
 
+import Base.get
+
 export RedisException, ConnectionException, ServerException, ProtocolException, ClientException
 export RedisConnection, SentinelConnection, TransactionConnection, SubscriptionConnection,
        disconnect, is_connected, open_transaction, reset_transaction, open_subscription

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -41,7 +41,7 @@ end
 # Integer replies are just ints followed by CRLF
 function parse_integer_reply(reply, first_crlf)
     try
-        ParsedReply(parseint(reply[2:first_crlf.start-1]), first_crlf.stop)
+        ParsedReply(parse(Int, reply[2:first_crlf.start-1]), first_crlf.stop)
     catch
         throw(ProtocolException(reply))
     end
@@ -50,7 +50,7 @@ end
 # Bulk replies specify their length and then the binary-safe string
 function parse_bulk_reply(reply, first_crlf)
     try
-        bulk_length = parseint(reply[2:first_crlf.start-1])
+        bulk_length = parse(Int, reply[2:first_crlf.start-1])
         bulk_length == -1 && return ParsedReply(nothing, first_crlf.stop)
         reply_end = first_crlf.stop+bulk_length
         ParsedReply(reply[first_crlf.stop+1:reply_end], reply_end+2)
@@ -63,7 +63,7 @@ end
 # for each item in length
 function parse_array_reply(reply, first_crlf)
     try
-        array_length = parseint(reply[2:first_crlf.start-1])
+        array_length = parse(Int, reply[2:first_crlf.start-1])
         array_length == -1 && return ParsedReply(nothing, first_crlf.stop)
         reply = reply[first_crlf.stop+1:end]
         reply_length = first_crlf.stop


### PR DESCRIPTION
Changed `parseint(foo) to `parse(Int, foo)` to remove deprecation warnings. Also added `import Base.get` to `Redis.jl` so that `get()` can be used without qualifying it.