### PR TITLE
Use dirname(@__FILE__) instead of Pkg.dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,14 @@
 services:
   - redis-server
-language: cpp
-compiler:
-  - clang
+language: julia
+julia:
+  - 0.4
+  - 0.5
+  - nightly
 notifications:
   email: false
-env:
-  matrix:
-    - JULIAVERSION="juliareleases"
-    - JULIAVERSION="julianightlies"
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-script:
-  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.add("DataStructures"); Pkg.add("BaseTestNext"); Pkg.test("Redis", coverage=true)'
+#script: # use the default script setting which is equivalent to the following
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.init(); Pkg.clone(pwd()); Pkg.test("Redis", coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("Redis")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder())'

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+BaseTestNext

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,5 +8,5 @@ else
     const Test = BaseTestNext
 end
 
-include(Pkg.dir("Redis","test","client_tests.jl"))
-include(Pkg.dir("Redis","test","redis_tests.jl"))
+include(joinpath(dirname(@__FILE__),"client_tests.jl"))
+include(joinpath(dirname(@__FILE__),"redis_tests.jl"))


### PR DESCRIPTION
This allows installing the package elsewhere.

Modernize Travis - this allows testing against more versions of Julia

Move installation of BaseTestNext into test/REQUIRE